### PR TITLE
Add support for GFM syntax hinting

### DIFF
--- a/src/endophile/core.clj
+++ b/src/endophile/core.clj
@@ -144,7 +144,12 @@
 (extend-type VerbatimNode AstToClj
   (to-clj [node]
     {:tag :pre
-     :content (list {:tag :code :content (list (.getText node))})}))
+     :content (list (merge {:tag :code
+                            :content (list (.getText node))}
+                           (when-let [c (.getType node)]
+                             (if-not (or (str/blank? c)
+                                         (nil? c))
+                               {:attrs {:class c}}))))}))
 
 (extend-type RefLinkNode AstToClj
   (to-clj [node]

--- a/src/endophile/hiccup.clj
+++ b/src/endophile/hiccup.clj
@@ -148,7 +148,12 @@
 
 (extend-type VerbatimNode AstToHiccup
   (to-hiccup [node]
-    [:pre [:code (verbatim-xml-str (.getText node))]]))
+    [:pre [:code
+           (when-let [c (.getType node)]
+             (if-not (or (str/blank? c)
+                         (nil? c))
+               {:class c}))
+           (verbatim-xml-str (.getText node))]]))
 
 (extend-type RefLinkNode AstToHiccup
   (to-hiccup [node]

--- a/test/resources/GFM-code.html
+++ b/test/resources/GFM-code.html
@@ -1,0 +1,5 @@
+<pre><code>(comment tilde-deliminated fenced code block without syntax hint)
+</code></pre><pre><code class="clojure">(comment tilde-deliminated fenced code block with syntax hint)
+</code></pre><pre><code>(comment backtick-deliminated fenced code block without syntax hint)
+</code></pre><pre><code class="clojure">(comment backtick-deliminated fenced code block with syntax hint)
+</code></pre>

--- a/test/resources/GFM-code.text
+++ b/test/resources/GFM-code.text
@@ -1,0 +1,15 @@
+~~~
+(comment tilde-deliminated fenced code block without syntax hint)
+~~~
+
+~~~clojure
+(comment tilde-deliminated fenced code block with syntax hint)
+~~~
+
+```
+(comment backtick-deliminated fenced code block without syntax hint)
+```
+
+```clojure
+(comment backtick-deliminated fenced code block with syntax hint)
+```


### PR DESCRIPTION
This patch adds support to endophile to report the GFM fenced code blocks syntax highlighting. For example, for the following markdown the patch puts the string "clojure" in the class attribute for the code block:
    ~~~clojure
    (comment code)
    ~~~
