### PR TITLE
Stringify image alt attribute

### DIFF
--- a/src/endophile/hiccup.clj
+++ b/src/endophile/hiccup.clj
@@ -81,7 +81,7 @@
 
 (extend-type ExpImageNode AstToHiccup
   (to-hiccup [node]
-    [:img {:src (.url node) :title (.title node) :alt (clj-contents node)}]))
+    [:img {:src (.url node) :title (.title node) :alt (apply str (clj-contents node))}]))
 
 (extend-type ExpLinkNode AstToHiccup
   (to-hiccup [node]


### PR DESCRIPTION
Otherwise the alt attribute is serialized unhelpfully as "clojure.lang.LazySeq@5faa97a"