### PR TITLE
add support for tables

### DIFF
--- a/src/endophile/hiccup.clj
+++ b/src/endophile/hiccup.clj
@@ -8,7 +8,9 @@
             ExpLinkNode HeaderNode HtmlBlockNode InlineHtmlNode MailLinkNode
             OrderedListNode ParaNode QuotedNode QuotedNode$Type SimpleNode
             SimpleNode$Type SpecialTextNode StrongEmphSuperNode VerbatimNode
-            ReferenceNode StrikeNode AnchorLinkNode]))
+            ReferenceNode StrikeNode AnchorLinkNode TableNode
+            TableHeaderNode TableBodyNode TableRowNode TableCellNode
+            TableColumnNode TableColumnNode$Alignment TableCaptionNode]))
 
 (defn- sequential-but-not-vector? [s]
   (and (sequential? s) (not (vector? s))))
@@ -32,84 +34,89 @@
 (defn- html-snippet [s]
   (clj2hiccup (html/html-snippet s)))
 
-(declare ^:dynamic *references*)
-
 (defprotocol AstToHiccup
-  (to-hiccup [node]))
+  (to-hiccup-with-context [node context]))
 
-(defn clj-contents [node]
-  (doall (flatten* (map to-hiccup (seq (.getChildren node))))))
+(defn to-hiccup [node]
+  (to-hiccup-with-context node {}))
+
+(defn clj-contents [node context]
+  (doall (flatten* (map #(to-hiccup-with-context % context)
+                        (seq (.getChildren node))))))
 
 (extend-type SuperNode AstToHiccup
-  (to-hiccup [node] (clj-contents node)))
+  (to-hiccup-with-context [node context] (clj-contents node context)))
 
 (extend-type RootNode AstToHiccup
-  (to-hiccup [node]
-    (binding [*references*
-              (into {}
-                    (for [ref (.getReferences node)]
-                      [(first (clj-contents ref)) ref]))]
-     (clj-contents node))))
+  (to-hiccup-with-context [node context]
+    (clj-contents node
+                  (add-references context
+                                  clj-contents
+                                  (.getReferences node)))))
 
 (extend-type BulletListNode AstToHiccup
-  (to-hiccup [node] (vec (cons :ul (clj-contents node)))))
+  (to-hiccup-with-context [node context]
+    (vec (cons :ul (clj-contents node context)))))
 
 (extend-type ListItemNode AstToHiccup
-  (to-hiccup [node]
-    (vec (cons :li (flatten* (map to-hiccup (seq (.getChildren node))))))))
+  (to-hiccup-with-context [node context]
+    (vec (cons :li (flatten* (map #(to-hiccup-with-context % context)
+                                  (seq (.getChildren node))))))))
 
 (extend-type TextNode AstToHiccup
-  (to-hiccup [node] (xml-str (.getText node))))
+  (to-hiccup-with-context [node _] (xml-str (.getText node))))
 
 (extend-type AutoLinkNode AstToHiccup
-  (to-hiccup [node]
+  (to-hiccup-with-context [node _]
     [:a {:href (.getText node)}
      (xml-str (.getText node))]))
 
 (extend-type BlockQuoteNode AstToHiccup
-  (to-hiccup [node]
-    (vec (cons :blockquote (clj-contents node)))))
+  (to-hiccup-with-context [node context]
+    (vec (cons :blockquote (clj-contents node context)))))
 
 (extend-type CodeNode AstToHiccup
-  (to-hiccup [node]
+  (to-hiccup-with-context [node _]
     [:code (verbatim-xml-str (.getText node))]))
 
 (extend-type ExpImageNode AstToHiccup
-  (to-hiccup [node]
-    [:img {:src (.url node) :title (.title node) :alt (apply str (clj-contents node))}]))
+  (to-hiccup-with-context [node context]
+    [:img {:src   (.url node)
+           :title (.title node)
+           :alt   (apply str (clj-contents node context))}]))
 
 (extend-type ExpLinkNode AstToHiccup
-  (to-hiccup [node]
+  (to-hiccup-with-context [node context]
     (vec
      (concat
       [:a (a-attrs {:href (.url node) :title (.title node)})]
-      (clj-contents node)))))
+      (clj-contents node context)))))
 
 (extend-type HeaderNode AstToHiccup
-  (to-hiccup [node]
+  (to-hiccup-with-context [node context]
     (vec (cons (keyword (str "h" (.getLevel node)))
-               (clj-contents node)))))
+               (clj-contents node context)))))
 
 (extend-type HtmlBlockNode AstToHiccup
-  (to-hiccup [node]
+  (to-hiccup-with-context [node _]
     (html-snippet (.getText node))))
 
 (extend-type InlineHtmlNode AstToHiccup
-  (to-hiccup [node]
+  (to-hiccup-with-context [node _]
     (html-snippet (.getText node))))
 
 (extend-type MailLinkNode AstToHiccup
-  (to-hiccup [node]
+  (to-hiccup-with-context [node _]
     (vec (concat [:a {:href (str "mailto:" (.getText node))}]
                  (list (.getText node))))))
 
 (extend-type OrderedListNode AstToHiccup
-  (to-hiccup [node]
-    (vec (cons :ol (clj-contents node)))))
+  (to-hiccup-with-context [node context]
+    (vec (cons :ol (clj-contents node context)))))
 
 (extend-type ParaNode AstToHiccup
-  (to-hiccup [node]
-    (vec (cons :p (clj-contents node)))))
+  (to-hiccup-with-context [node context]
+    (vec (cons :p (clj-contents node context)))))
 
 (def qts
   {QuotedNode$Type/DoubleAngle [\u00AB \u00BB]
@@ -117,10 +124,10 @@
    QuotedNode$Type/Single [\u2018 \u2019]})
 
 (extend-type QuotedNode AstToHiccup
-  (to-hiccup [node]
+  (to-hiccup-with-context [node context]
     (vec (cons :p (flatten*
                    (let [q (qts (.getType node))]
-                     (list (q 0) (clj-contents node) (q 1))))))))
+                     (list (q 0) (clj-contents node context) (q 1))))))))
 
 (def simple-nodes
   {SimpleNode$Type/Apostrophe \'
@@ -132,25 +139,27 @@
    SimpleNode$Type/Nbsp \u00A0})
 
 (extend-type SimpleNode AstToHiccup
-  (to-hiccup [node] (simple-nodes (.getType node))))
+  (to-hiccup-with-context [node _] (simple-nodes (.getType node))))
 
 (extend-type SpecialTextNode AstToHiccup
-  (to-hiccup [node] (xml-str (.getText node))))
+  (to-hiccup-with-context [node _] (xml-str (.getText node))))
 
 (extend-type StrongEmphSuperNode AstToHiccup
-  (to-hiccup [node]
-    (vec (cons (if (.isStrong node) :strong :em) (clj-contents node)))))
+  (to-hiccup-with-context [node context]
+    (vec (cons (if (.isStrong node) :strong :em)
+               (clj-contents node context)))))
 
 (extend-type StrikeNode AstToHiccup
-  (to-hiccup [node]
-    (vec (cons :del (clj-contents node)))))
+  (to-hiccup-with-context [node context]
+    (vec (cons :del (clj-contents node context)))))
 
 (extend-type AnchorLinkNode AstToHiccup
-  (to-hiccup [node]
-    (vector :a {:name (.getName node) :href (str "#" (.getName node))} (xml-str (.getText node)))))
+  (to-hiccup-with-context [node _]
+    (vector :a {:name (.getName node):href (str "#" (.getName node))}
+            (xml-str (.getText node)))))
 
 (extend-type VerbatimNode AstToHiccup
-  (to-hiccup [node]
+  (to-hiccup-with-context [node _]
     [:pre [:code
            (when-let [c (.getType node)]
              (if-not (or (str/blank? c)
@@ -159,11 +168,12 @@
            (verbatim-xml-str (.getText node))]]))
 
 (extend-type RefLinkNode AstToHiccup
-  (to-hiccup [node]
-    (let [contents (clj-contents node)
+  (to-hiccup-with-context [node context]
+    (let [contents (clj-contents node context)
           key (if-let [nd (.referenceKey node)]
-                (str/join (to-hiccup nd)) (str/join contents))]
-     (if-let [ref (*references* key)]
+                (str/join (to-hiccup-with-context nd context))
+                (str/join contents))]
+     (if-let [ref ((:references context) key)]
        [:a (a-attrs {:href (.getUrl ref) :title (.getTitle ref)}) contents]
        (cons "[" (concat contents
                          (if (.separatorSpace node)
@@ -173,5 +183,43 @@
                              ["]"])))))))
 
 (extend-type ReferenceNode AstToHiccup
-  (to-hiccup [node]
+  (to-hiccup-with-context [_ _]
     nil))
+
+(extend-type TableNode AstToHiccup
+  (to-hiccup-with-context [node context]
+    (vec (cons :table (clj-contents node
+                                    (assoc context :table-columns
+                                           (.getColumns node)))))))
+
+(extend-type TableHeaderNode AstToHiccup
+  (to-hiccup-with-context [node context]
+    (vec (cons :thead (clj-contents node (assoc context :in-header true))))))
+
+(extend-type TableBodyNode AstToHiccup
+  (to-hiccup-with-context [node context]
+    (vec (cons :tbody (clj-contents node (assoc context :in-header false))))))
+
+(extend-type TableRowNode AstToHiccup
+  (to-hiccup-with-context [node context]
+    (vec (cons :tr (table-row-contents flatten*
+                                       to-hiccup-with-context
+                                       node context)))))
+
+(extend-type TableCellNode AstToHiccup
+  (to-hiccup-with-context [node context]
+    (let [alignment (.getAlignment (:column context))
+          attrs (merge {}
+                       (when (> (.getColSpan node) 1)
+                         {:colspan (.getColSpan node)})
+                       (when (not= alignment
+                                   TableColumnNode$Alignment/None)
+                         {:alignment (column-alignment alignment)}))]
+      (vec (remove nil?
+                   (concat [(if (:in-header context) :th :td)
+                            (when (not (empty? attrs)) attrs)]
+                           (clj-contents node context)))))))
+
+(extend-type TableCaptionNode AstToHiccup
+  (to-hiccup-with-context [node context]
+    (vec (cons :caption (clj-contents node context)))))

--- a/test/endophile/core_test.clj
+++ b/test/endophile/core_test.clj
@@ -80,3 +80,114 @@
          (to-clj (mp "juho@metosin.fi"))))
   (is (= [[:p [:a {:href "mailto:juho@metosin.fi"} "juho@metosin.fi"]]]
          (md2h/to-hiccup (mp "juho@metosin.fi")))) )
+
+(deftest tables-test
+  (let [table-md (mp (str "| A | B \n"
+                          "| - | - |\n"
+                          "| C | D |\n"
+                          "[Caption]")
+                     {:extensions {:tables true}})]
+    (is (= [{:tag :table
+             :content
+             [{:tag :thead
+               :content
+               [{:tag :tr
+                 :content [{:tag :th, :content ["A "]}
+                           {:tag :th, :content ["B"]}]}]}
+              {:tag :tbody
+               :content
+               [{:tag :tr
+                 :content [{:tag :td, :content ["C "]}
+                           {:tag :td, :content ["D "]}]}]}
+              {:tag :caption
+               :content ["Caption"]}]}]
+           (to-clj table-md)))
+    (is (= [[:table
+             [:thead [:tr [:th "A "] [:th "B"]]]
+             [:tbody [:tr [:td "C "] [:td "D "]]]
+             [:caption "Caption"]]]
+           (md2h/to-hiccup table-md))))
+
+  (let [headless-md (mp (str "| -------- |\n"
+                             "| headless |\n")
+                        {:extensions {:tables true}})]
+    (is (= [{:tag :table
+             :content [{:tag :tbody
+                        :content
+                        [{:tag :tr
+                          :content [{:tag :td, :content ["headless "]}]}]}]}]
+           (to-clj headless-md)))
+    (is (= [[:table [:tbody [:tr [:td "headless "]]]]]
+           (md2h/to-hiccup headless-md))))
+
+  (let [column-md (mp (str "|     | GROUP   ||      |\n"
+                           "| HE  | AD  | ER | S    |\n"
+                           "|:--- | ---:| -- |:----:|\n"
+                           "| A   | B   | CCC      ||\n"
+                           "| D   | E   |  F | GG   |\n"
+                           "| HH  |  I      ||  J   |\n"
+                           "[Caption]")
+                      {:extensions {:tables true}})]
+    (is (= [{:tag :table
+             :content
+             [{:tag :thead
+               :content
+               [{:tag :tr
+                 :content
+                 [{:tag :th,  :content [" "], :attrs {:alignment "left"}}
+                  {:tag :th, :content ["GROUP "]
+                   :attrs {:colspan 2, :alignment "right"}}
+                  {:tag :th, :content [" "], :attrs {:alignment "center"}}]}
+                {:tag :tr
+                 :content
+                 [{:tag :th, :content ["HE "], :attrs {:alignment "left"}}
+                  {:tag :th, :content ["AD "], :attrs {:alignment "right"}}
+                  {:tag :th, :content ["ER "]}
+                  {:tag :th, :content ["S "], :attrs {:alignment "center"}}]}]}
+              {:tag :tbody
+               :content
+               [{:tag :tr
+                 :content
+                 [{:tag :td, :content ["A "], :attrs {:alignment "left"}}
+                  {:tag :td, :content ["B "], :attrs {:alignment "right"}}
+                  {:tag :td, :content ["CCC "], :attrs {:colspan 2}}]}
+                {:tag :tr
+                 :content
+                 [{:tag :td, :content ["D "], :attrs {:alignment "left"}}
+                  {:tag :td, :content ["E "], :attrs {:alignment "right"}}
+                  {:tag :td, :content ["F "]}
+                  {:tag :td, :content ["GG "], :attrs {:alignment "center"}}]}
+                {:tag :tr
+                 :content
+                 [{:tag :td, :content ["HH "], :attrs {:alignment "left"}}
+                  {:tag :td, :content ["I "]
+                   :attrs {:colspan 2, :alignment "right"}}
+                  {:tag :td, :content ["J "], :attrs {:alignment "center"}}]}]}
+              {:tag :caption, :content ["Caption"]}]}]
+           (to-clj column-md)))
+    (is (= [[:table
+             [:thead
+              [:tr
+               [:th {:alignment "left"} " "]
+               [:th {:colspan 2, :alignment "right"} "GROUP "]
+               [:th {:alignment "center"} " "]]
+              [:tr
+               [:th {:alignment "left"} "HE "]
+               [:th {:alignment "right"} "AD "]
+               [:th "ER "]
+               [:th {:alignment "center"} "S "]]]
+             [:tbody
+              [:tr
+               [:td {:alignment "left"} "A "]
+               [:td {:alignment "right"} "B "]
+               [:td {:colspan 2} "CCC "]]
+              [:tr [:td {:alignment "left"} "D "]
+               [:td {:alignment "right"} "E "]
+               [:td "F "]
+               [:td {:alignment "center"} "GG "]]
+              [:tr
+               [:td {:alignment "left"} "HH "]
+               [:td {:colspan 2, :alignment "right"} "I "]
+               [:td {:alignment "center"} "J "]]]
+             [:caption "Caption"]]]
+           (md2h/to-hiccup column-md)))))


### PR DESCRIPTION
Hi,
I added support for tables. This required some extensive changes due to the need for context during the AST traversal. You can see that the changes caused no changes to the existing tests, but I had to change `to-clj` and `to-hiccup` to regular functions.

I also reimplemented the support for references with the context.